### PR TITLE
Rust toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = [ "wasm32-unknown-unknown" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "stable"
 targets = [ "wasm32-unknown-unknown" ]
+components = [ "rust-src", "rust-analyzer" ]


### PR DESCRIPTION
Declare the Rust toolchain used, alleviating the need to manually run `rustup target add wasm32-unknown-unknown` to work on the repository.

This does not lock the rust toolchain or provide any other dependencies (e.g. `cc`) or CI related things, since this change stands on its own.

## Considered components

This is hopefully a comprehensive list of components that I considered for inclusion, taken from the [rustup docs](https://rust-lang.github.io/rustup/concepts/components.html):

### Added: optional developer tooling components (LSP support)

> - rust-src — This is a local copy of the source code of the Rust standard library. This can be used by some tools, such as [RLS](https://github.com/rust-lang/rls), to provide auto-completion for functions within the standard library; [Miri](https://github.com/rust-lang/miri/) which is a Rust interpreter; and Cargo's experimental [build-std](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std) feature, which allows you to rebuild the standard library locally.
> - rust-analyzer — [rust-analyzer](https://rust-analyzer.github.io/) is a language server that provides support for editors and IDEs.

### Redundant (included by default)

> - rustc — The Rust compiler and [Rustdoc](https://doc.rust-lang.org/rustdoc/).
> - cargo — [Cargo](https://doc.rust-lang.org/cargo/) is a package manager and build tool.

> - clippy — [Clippy](https://github.com/rust-lang/rust-clippy) is a lint tool that provides extra checks for common mistakes and stylistic choices.
> - rust-docs — This is a local copy of the [Rust documentation](https://doc.rust-lang.org/). Use the rustup doc command to open the documentation in a web browser. Run rustup doc --help for more options.
> - rustfmt — [Rustfmt](https://github.com/rust-lang/rustfmt) is a tool for automatically formatting code.

### Seemingly irrelevant?

I either don't know/understand what these provide, or they don't seem relevant (at least not for now).

> - rust-std — This is the Rust [standard library](https://doc.rust-lang.org/std/). There is a separate rust-std component for each target that rustc supports, such as rust-std-x86_64-pc-windows-msvc. See the [Cross-compilation](https://rust-lang.github.io/rustup/cross-compilation.html) chapter for more detail.
> - rust-analysis — Metadata about the standard library, used by tools like [RLS](https://github.com/rust-lang/rls).
> - miri — [Miri](https://github.com/rust-lang/miri/) is an experimental Rust interpreter, which can be used for checking for undefined-behavior.
> - llvm-tools-preview — This is an experimental component which contains a collection of [LLVM](https://llvm.org/) tools.
> - rust-mingw — This contains a linker and platform libraries for building on the x86_64-pc-windows-gnu platform.
> - rustc-dev — This component contains the compiler as a library. Most users will not need this; it is only needed for development of tools that link to the compiler, such as making modifications to [Clippy](https://github.com/rust-lang/rust-clippy).
> - ~rls — [RLS](https://github.com/rust-lang/rls) is a language server that is deprecated and has been replaced by rust-analyzer.~
