### PR TITLE
Clean slate for clippy #ACAB

### DIFF
--- a/crates/carol/src/bin/carol.rs
+++ b/crates/carol/src/bin/carol.rs
@@ -54,7 +54,7 @@ pub async fn main() -> anyhow::Result<()> {
             tracing::subscriber::set_global_default(subscriber)?;
             event!(Level::INFO, "starting carol");
 
-            let state = State::new(Executor::new(), config.bls_secret_key);
+            let state = State::new(Executor::default(), config.bls_secret_key);
 
             carol::http::server::start(config.http_server, state).await?;
         }

--- a/crates/carol/src/config.rs
+++ b/crates/carol/src/config.rs
@@ -30,10 +30,11 @@ impl Default for HttpServerConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, Copy, serde::Deserialize, serde::Serialize)]
 pub enum Level {
     Error,
     Warn,
+    #[default]
     Info,
     Debug,
     Trace,
@@ -54,12 +55,6 @@ impl From<Level> for tracing::Level {
 impl From<Level> for tracing::level_filters::LevelFilter {
     fn from(value: Level) -> Self {
         tracing::Level::from(value).into()
-    }
-}
-
-impl Default for Level {
-    fn default() -> Self {
-        Level::Info
     }
 }
 

--- a/crates/carol/src/http/server.rs
+++ b/crates/carol/src/http/server.rs
@@ -323,7 +323,7 @@ pub async fn dispatch(
                 let compiled_binary = state
                     .get_binary(binary_id)
                     .ok_or(Problem::not_found(path))?;
-                (binary_id, params.clone(), compiled_binary.clone())
+                (binary_id, params, compiled_binary)
             };
 
             match method {
@@ -376,7 +376,7 @@ pub async fn dispatch(
                 let compiled_binary = state
                     .get_binary(binary_id)
                     .ok_or(Problem::not_found(path))?;
-                (params.clone(), compiled_binary.clone())
+                (params, compiled_binary)
             };
 
             let transformed_uri = {

--- a/crates/carol/src/http/server.rs
+++ b/crates/carol/src/http/server.rs
@@ -147,7 +147,7 @@ impl Problem {
     }
 
     pub fn into_bincode_body(self) -> Vec<u8> {
-        bincode::encode_to_vec(&self.client_desc, bincode::config::standard()).unwrap()
+        bincode::encode_to_vec(self.client_desc, bincode::config::standard()).unwrap()
     }
 
     pub fn into_json_body(self) -> Vec<u8> {

--- a/crates/carol/src/http/server.rs
+++ b/crates/carol/src/http/server.rs
@@ -232,7 +232,7 @@ pub async fn dispatch(
 ) -> Result<Response<Body>, Problem> {
     let path = req.uri().path();
     let segments = {
-        let mut segments = path.split("/");
+        let mut segments = path.split('/');
         // ignore first `/`
         let _ = segments.next();
         segments.collect::<Vec<_>>()

--- a/crates/carol_bls/src/lib.rs
+++ b/crates/carol_bls/src/lib.rs
@@ -13,7 +13,7 @@ pub struct KeyPair {
 
 impl KeyPair {
     pub fn new(sk: bls12_381::Scalar) -> Self {
-        let pk = bls12_381::G1Affine::generator() * &sk;
+        let pk = bls12_381::G1Affine::generator() * sk;
         Self { pk: pk.into(), sk }
     }
 

--- a/crates/carol_guest/src/lib.rs
+++ b/crates/carol_guest/src/lib.rs
@@ -1,4 +1,3 @@
-#[allow(unused)]
 #[macro_use]
 extern crate alloc;
 

--- a/crates/carol_guest_derive/src/lib.rs
+++ b/crates/carol_guest_derive/src/lib.rs
@@ -397,5 +397,5 @@ fn carol_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
 
     };
 
-    output.into()
+    output
 }

--- a/crates/carol_guest_derive/src/lib.rs
+++ b/crates/carol_guest_derive/src/lib.rs
@@ -242,7 +242,7 @@ fn carol_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
                 comma: None,
             });
 
-            let route = format!("/activate/{}", method.sig.ident.to_string());
+            let route = format!("/activate/{}", method.sig.ident);
 
             let handle_output = match method.sig.output {
                 ReturnType::Default => quote_spanned! { method.sig.span() => http::Response {
@@ -254,12 +254,12 @@ fn carol_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
                     let bincode_decode_output_expect = format!(
                         "#[carol] bincode decoding the output of {} to type {}",
                         method_name,
-                        ty.to_token_stream().to_string()
+                        ty.to_token_stream()
                     );
                     let json_encode_output_expect = format!(
                         "#[carol]] JSON encoding the output of {} from type {}",
                         method_name,
-                        ty.to_token_stream().to_string()
+                        ty.to_token_stream()
                     );
                     quote_spanned! { ty.span() =>  {
                         let (decoded_output, _) : (#ty, _) = bincode::decode_from_slice(&output, bincode::config::standard()).expect(#bincode_decode_output_expect);

--- a/crates/carol_guest_derive/src/lib.rs
+++ b/crates/carol_guest_derive/src/lib.rs
@@ -70,11 +70,10 @@ fn carol_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
 
     for item in input.items.clone() {
         if let ImplItem::Method(method) = item {
-            if method
+            if !method
                 .attrs
                 .iter()
-                .find(|attr| attr.path.to_token_stream().to_string() == "activate")
-                .is_none()
+                .any(|attr| attr.path.to_token_stream().to_string() == "activate")
             {
                 continue;
             }

--- a/crates/carol_guest_derive/src/lib.rs
+++ b/crates/carol_guest_derive/src/lib.rs
@@ -277,7 +277,7 @@ fn carol_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
             let struct_path: Path = parse_quote!(#carol_mod::#struct_path);
             let json_decode_error = format!(
                 "#[carol] decoding JSON to {}",
-                struct_path.to_token_stream().to_string().replace(" ", "")
+                struct_path.to_token_stream().to_string().replace(' ', "")
             );
             let bincode_encode_error =
                 format!("#[carol] bincode encoding input to {}", method_name);
@@ -336,12 +336,12 @@ fn carol_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let self_ty = input.self_ty.clone();
     let params_decode_expect = format!(
         "#[carol] bincode decoding parameters as {}",
-        self_ty.to_token_stream().to_string().replace(" ", "")
+        self_ty.to_token_stream().to_string().replace(' ', "")
     );
     let enum_path: Path = parse_quote!(#carol_mod::#enum_name);
     let input_decode_expect = format!(
         "#[carol] bincode decoding input as {}",
-        enum_path.to_token_stream().to_string().replace(" ", "")
+        enum_path.to_token_stream().to_string().replace(' ', "")
     );
 
     let output = quote! {

--- a/crates/carol_guest_derive/tests/method_call.rs
+++ b/crates/carol_guest_derive/tests/method_call.rs
@@ -1,3 +1,4 @@
+#![allow(renamed_and_removed_lints, unknown_lints, disallowed_names)]
 use carol_guest::bind::machine::Machine;
 use carol_guest_derive::{activate, carol};
 use core::any::Any;

--- a/crates/carol_host/src/host_bindings.rs
+++ b/crates/carol_host/src/host_bindings.rs
@@ -31,7 +31,7 @@ pub enum Environment {
 impl Environment {
     pub fn http_client(&self) -> &reqwest::Client {
         match self {
-            Environment::Activation { http_client, .. } => &http_client,
+            Environment::Activation { http_client, .. } => http_client,
             Environment::Http { .. } => {
                 panic!("cannot use http client in http handler environment")
             }
@@ -79,7 +79,7 @@ impl global::Host for Host {
 
     async fn bls_static_sign(&mut self, message: Vec<u8>) -> anyhow::Result<Vec<u8>> {
         Ok(
-            carol_bls::sign(&self.state.bls_keypair(), self.machine_id, &message)
+            carol_bls::sign(self.state.bls_keypair(), self.machine_id, &message)
                 .0
                 .to_uncompressed()
                 .to_vec(),

--- a/crates/carol_host/src/host_bindings.rs
+++ b/crates/carol_host/src/host_bindings.rs
@@ -160,7 +160,7 @@ impl<'a> TryFrom<http::RequestParam<'a>> for http_crate::Request<hyper::Body> {
     }
 }
 
-impl<'a> TryFrom<http::RequestResult> for http_crate::Request<hyper::Body> {
+impl TryFrom<http::RequestResult> for http_crate::Request<hyper::Body> {
     type Error = anyhow::Error;
 
     fn try_from(guest_request: http::RequestResult) -> Result<Self, Self::Error> {
@@ -185,7 +185,7 @@ impl<'a> TryFrom<http::RequestParam<'a>> for reqwest::Request {
     }
 }
 
-impl<'a> TryFrom<http::RequestResult> for reqwest::Request {
+impl TryFrom<http::RequestResult> for reqwest::Request {
     type Error = anyhow::Error;
 
     fn try_from(value: http::RequestResult) -> Result<Self, Self::Error> {

--- a/crates/carol_host/src/lib.rs
+++ b/crates/carol_host/src/lib.rs
@@ -143,7 +143,7 @@ impl Executor {
         // // but in the Wasmtime embedding API the first argument is always a `Store`.
         let output = bindings
             .machine()
-            .call_activate(&mut store, &machine_params, &activation_input)
+            .call_activate(&mut store, machine_params, activation_input)
             .instrument(span)
             .await;
 

--- a/crates/carol_host/src/lib.rs
+++ b/crates/carol_host/src/lib.rs
@@ -248,3 +248,9 @@ impl Executor {
         }
     }
 }
+
+impl Default for Executor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/carol_host/src/state.rs
+++ b/crates/carol_host/src/state.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 use crate::{BinaryId, CompiledBinary, Executor, MachineId};
 use carol_bls as bls;
 use std::collections::HashMap;

--- a/example-crates/bitmex/guest/src/lib.rs
+++ b/example-crates/bitmex/guest/src/lib.rs
@@ -64,7 +64,7 @@ impl BitMexAttest {
                 bit_index: bit_index as u8,
                 bit_value,
             };
-            let message = bincode::encode_to_vec(&attest_bit, bincode::config::standard()).unwrap();
+            let message = bincode::encode_to_vec(attest_bit, bincode::config::standard()).unwrap();
             cap.bls_static_sign(&message)
         });
 
@@ -90,8 +90,7 @@ impl BitMexAttest {
             symbol,
         };
 
-        let encoded_message =
-            bincode::encode_to_vec(&message, bincode::config::standard()).unwrap();
+        let encoded_message = bincode::encode_to_vec(message, bincode::config::standard()).unwrap();
 
         let signature = cap.bls_static_sign(&encoded_message);
 
@@ -131,11 +130,11 @@ impl BitMexAttest {
             timestamp_hour: time.hour(),
             timestamp_min: time.minute(),
             timestamp_second: 0,
-            symbol: &symbol,
+            symbol,
         })
         .expect("serializes correctly");
         url.query_pairs_mut()
-            .append_pair("symbol", &symbol) // only interested in index
+            .append_pair("symbol", symbol) // only interested in index
             .append_pair("filter", &filter)
             .append_pair("columns", "lastPrice,timestamp"); // only necessary fields
 

--- a/example-crates/bitmex/run/src/main.rs
+++ b/example-crates/bitmex/run/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let call = bincode::encode_to_vec(
-        &carol_activate::Activate::AttestToPriceAtMinute(method),
+        carol_activate::Activate::AttestToPriceAtMinute(method),
         bincode::config::standard(),
     )
     .unwrap();

--- a/example-crates/bitmex/run/src/main.rs
+++ b/example-crates/bitmex/run/src/main.rs
@@ -6,7 +6,7 @@ use carol_host::{Executor, State};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let state = State::new(
-        Executor::new(),
+        Executor::default(),
         bls::KeyPair::random(&mut rand::thread_rng()),
     );
     let binary = state

--- a/example-crates/hello_world/run/src/main.rs
+++ b/example-crates/hello_world/run/src/main.rs
@@ -6,7 +6,7 @@ use hello_world::carol_activate;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let state = State::new(
-        Executor::new(),
+        Executor::default(),
         bls::KeyPair::random(&mut rand::thread_rng()),
     );
     let binary = state

--- a/example-crates/hello_world/run/src/main.rs
+++ b/example-crates/hello_world/run/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
         .context("target/hello_world.wasm not found. Make sure to build it first!")?;
 
     let call = bincode::encode_to_vec(
-        &carol_activate::Activate::Say(carol_activate::Say {
+        carol_activate::Activate::Say(carol_activate::Say {
             message: "world!!!".into(),
         }),
         bincode::config::standard(),


### PR DESCRIPTION
Addresses all of the clippy lints except one which was silent, so that that automated checks will have a clean signal for new PRs when CI is added.