### PR TITLE
Add network_tests feature

### DIFF
--- a/example-crates/bitmex/guest/Cargo.toml
+++ b/example-crates/bitmex/guest/Cargo.toml
@@ -3,7 +3,8 @@ name = "bitmex_guest"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+network_tests = []
 
 [dependencies]
 carol_guest = { workspace = true }

--- a/example-crates/bitmex/guest/src/lib.rs
+++ b/example-crates/bitmex/guest/src/lib.rs
@@ -147,12 +147,11 @@ impl BitMexAttest {
 
 #[cfg(test)]
 mod test {
-    use carol_guest::TestCap;
-
-    use crate::{BitMexAttest, OffsetDateTime};
-
+    #[cfg(feature = "network_tests")]
     #[test]
     fn index_price_at_minute() {
+        use crate::{BitMexAttest, OffsetDateTime};
+        use carol_guest::TestCap;
         let time = OffsetDateTime(time::macros::datetime!(2023-04-15 0:00 UTC));
         let cap = TestCap::default();
         let index_price = BitMexAttest


### PR DESCRIPTION
Tests should not contact the network by default since this may cause false positive failures in sandboxed environments or during network outages.