### PR TITLE
prune workspace deps with `cargo machete --fix`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,15 +310,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode 2.0.0-rc.3",
  "carol_bls",
  "carol_core",
  "http",
  "hyper",
  "rand",
  "reqwest",
- "sha2 0.9.9",
- "time",
  "tracing",
  "wasmtime",
 ]
@@ -862,7 +859,6 @@ dependencies = [
  "hello_world",
  "rand",
  "tokio",
- "wasmtime",
 ]
 
 [[package]]

--- a/crates/carol_host/Cargo.toml
+++ b/crates/carol_host/Cargo.toml
@@ -8,14 +8,11 @@ edition = "2021"
 [dependencies]
 wasmtime = { workspace = true }
 carol_bls = { workspace = true }
-sha2 = { workspace = true }
 reqwest = {  version = "0.11.16", features = ["rustls-tls"], default-features = false }
 http_crate = { workspace = true }
 anyhow = { workspace = true }
-time = { version = "0.3", features = ["std", "serde-human-readable"] }
 async-trait = "0.1"
 rand = "0.8"
 tracing = { workspace = true }
 carol_core = { workspace = true }
 hyper = { workspace = true }
-bincode = { workspace = true }

--- a/example-crates/hello_world/run/Cargo.toml
+++ b/example-crates/hello_world/run/Cargo.toml
@@ -11,6 +11,5 @@ hello_world = { path = "../guest" }
 bincode = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 carol_host = { workspace = true }
-wasmtime = { workspace = true }
 rand = { workspace = true }
 carol_bls = { workspace = true }


### PR DESCRIPTION
main motivation is clean slate for running `cargo machete` as a CI check